### PR TITLE
Clean up recentf list when closing diff-lsp tempfiles

### DIFF
--- a/diff-lsp.el
+++ b/diff-lsp.el
@@ -269,11 +269,22 @@ Example with default 4 header lines:
     (apply orig-fn args)))
 
 
+(defun diff-lsp--clean-recentf-list ()
+  "Remove all diff-lsp tempfiles from the global `recentf-list'.
+Matches entries whose filename (basename) begins with \"diff_lsp_\"."
+  (when (boundp 'recentf-list)
+    (setq recentf-list
+          (seq-remove (lambda (file)
+                        (string-match-p "\\`diff_lsp_"
+                                        (file-name-nondirectory (or file ""))))
+                      recentf-list))))
+
 (defun diff-lsp--text-document-did-close (orig-fn &rest args)
   (if (diff-lsp--valid-buffer)
       (progn
         ;; (message (mapconcat #'prin1-to-string args))
         (message "Skipping textDocument/didClose for diff-lsp tempfile.")
+        (diff-lsp--clean-recentf-list)
         (lsp-notify "textDocument/didClose"
                     `(:textDocument ,(lsp--text-document-identifier))))
     (apply orig-fn args)))


### PR DESCRIPTION
## Summary
This change prevents diff-lsp temporary files from accumulating in Emacs' recent file list by automatically removing them when the LSP session closes.

## Key Changes
- Added `diff-lsp--clean-recentf-list()` function that removes all temporary files matching the `diff_lsp_*` naming pattern from the global `recentf-list`
- Integrated the cleanup function into the `diff-lsp--text-document-did-close()` hook to execute whenever a diff-lsp tempfile's LSP session is closed
- The cleanup safely checks if `recentf-list` is bound before attempting to modify it

## Implementation Details
- Uses `seq-remove` with a regex pattern (`\`diff_lsp_`) to match tempfile basenames
- Handles edge cases like nil filenames with `(or file "")`
- Integrates seamlessly with the existing LSP didClose notification flow without affecting normal file handling

https://claude.ai/code/session_01PQFzaFMuXN46FQnmCAYZxJ